### PR TITLE
evasion: add hidden service note to evasion section

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,6 @@ or make the detection more difficult:
    * _In the following steps, the script deletes PowerShell logs and registers the final payload as a Windows service using a long command line with some strange permission settings. A quick Google search reveals that these are used to make the service hidden and unremovable using the regular Windows administration tools, without some additional actions. [Talos]_
    * _A little known feature of Windows allows the red team or an attacker to hide services from view, creating an opportunity to evade detection from common host-based threat hunting techniques. [SANS]_
 
-
-
 ## Testing
 
 Use the descriptions and information from the resources in section

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ If you have inputs then [pull requests](https://github.com/Karneades/malware-per
         * [All OSes and developer specific changes](#all-oses-and-developer-specific-changes)
     * [Overview of difficult to detect persistence mechanisms](#overview-of-difficult-to-detect-persistence-mechanisms)
     * [Links and resources for detection](#links-and-resources-for-detection)
-    * [Detection Evasion](#detection-evasion)
     * [Examples](#examples)
+* [Detection Evasion](#detection-evasion)
 * [Testing](#testing)
 * [Response](#response)
 * [Prevention](#prevention)
@@ -274,17 +274,6 @@ years as an inspiration what to look for.
  
 See [How malware persists on macOS](https://www.sentinelone.com/blog/how-malware-persists-on-macos/) for macOS persistence locations, General persistence mechanisms: [Common malware persistence mechanisms](https://resources.infosecinstitute.com/common-malware-persistence-mechanisms/), [Malware persistence techniques](https://www.andreafortuna.org/2017/07/06/malware-persistence-techniques/), WMI: [Detecting & Removing an Attacker’s WMI Persistence](https://medium.com/threatpunter/detecting-removing-wmi-persistence-60ccbb7dff96), Winlogon: [Windows Persistence using WinLogon](https://www.hackingarticles.in/windows-persistence-using-winlogon/), Kovter: [Untangling Kovter’s persistence methods](https://blog.malwarebytes.com/threat-analysis/2016/07/untangling-kovter/), [Threat Spotlight: Kovter Malware Fileless Persistence Mechanism](https://threatvector.cylance.com/en_us/home/threat-spotlight-kovter-malware-fileless-persistence-mechanism.html), GlobalFlags in Image File Execution Hijacks: [Persistence using GlobalFlags in Image File Execution Options – Hidden from Autoruns.exe](https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/), Bootloader persistence: [Uncovering a MyKings Variant With Bootloader Persistence via Managed Detection and Response](https://blog.trendmicro.com/trendlabs-security-intelligence/uncovering-a-mykings-variant-with-bootloader-persistence-via-managed-detection-and-response/), COM hijacking / CLSID hijacking: [gdatasoftware writeup from 2014](https://www.gdatasoftware.com/blog/2014/10/23941-com-object-hijacking-the-discreet-way-of-persistence) or [pentestlab writeup from 2020](https://pentestlab.blog/2020/05/20/persistence-com-hijacking/) or [Enigma0x3 / Matt Nelson's writeup from 2016 abusing com hijacking in combination with scheduled tasks](https://enigma0x3.net/2016/05/25/userland-persistence-with-scheduled-tasks-and-com-handler-hijacking/), Linux cron: [Linux Malware Persistence with Cron](https://www.sandflysecurity.com/blog/linux-malware-persistence-with-cron/), Microsoft Exchange and Outlook: [Hunting for persistence via Microsoft Exchange Server or Outlook](https://speakerdeck.com/heirhabarov/hunting-for-persistence-via-microsoft-exchange-server-or-outlook).
 
-### Detection Evasion
-
-Malware authors abuse different techniques to hide their malware persistence
-or make the detection more difficult:
-* Rootkits hide files or hook registry queries
-* Use similar or typosquatted names to OS default binary names 
-* Hidding entries by abusing program bugs, like the one with the null byte in registry keys which results in error while collection or just missing entries in the output of tools
-* [Abusing ADS (alternate data streams) in windows](https://argonsys.com/microsoft-cloud/library/latest-astaroth-living-off-the-land-attacks-are-even-more-invisible-but-not-less-observable/)
-* Using DLL side-loading for well-known binaries
-* Using signed binaries which then gets filtered out (depending on the analysis)
-
 ### Examples
 
 #### MITRE ATT&CK persistence technique called Local Job Scheduling
@@ -336,6 +325,22 @@ Sneaky persistence through manipulation of exefile file handler. [MITRE ATT&CK T
 ```
 
 and malware was dropped to `C:\Windows\svchost.com`.
+
+## Detection Evasion
+
+Malware authors abuse different techniques to hide their malware persistence
+or make the detection more difficult:
+* Rootkits hide files or hook registry queries
+* Use similar or typosquatted names to OS default binary names 
+* Hidding entries by abusing program bugs, like the one with the null byte in registry keys which results in error while collection or just missing entries in the output of tools
+* [Abusing ADS (alternate data streams) in windows](https://argonsys.com/microsoft-cloud/library/latest-astaroth-living-off-the-land-attacks-are-even-more-invisible-but-not-less-observable/)
+* Using DLL side-loading for well-known binaries
+* Using signed binaries which then gets filtered out (depending on the analysis)
+* Hidden services when special permissions were set at service creation. Seen in section _Installation stealth and persistence_ in Talos' blog post [Threat hunting in large datasets by clustering security events](https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html). This blog post references another one from SANS, [Red Team Tactics: Hiding Windows Services](https://www.sans.org/blog/red-team-tactics-hiding-windows-services/).
+   * _In the following steps, the script deletes PowerShell logs and registers the final payload as a Windows service using a long command line with some strange permission settings. A quick Google search reveals that these are used to make the service hidden and unremovable using the regular Windows administration tools, without some additional actions. [Talos]_
+   * _A little known feature of Windows allows the red team or an attacker to hide services from view, creating an opportunity to evade detection from common host-based threat hunting techniques. [SANS]_
+
+
 
 ## Testing
 


### PR DESCRIPTION
Hide services when special permissions were set at service creation. Seen in section Installation stealth and persistence in Talos' blog post Threat hunting in large datasets by clustering security events. This blog post references another one from SANS, Red Team Tactics: Hiding Windows Services.
* In the following steps, the script deletes PowerShell logs and registers the final payload as a Windows service using a long command line with some strange permission settings. A quick Google search reveals that these are used to make the service hidden and unremovable using the regular Windows administration tools, without some additional actions. [Talos]
* A little known feature of Windows allows the red team or an attacker to hide services from view, creating an opportunity to evade detection from common host-based threat hunting techniques. [SANS]

Formatting: move evasion section one level higher.